### PR TITLE
Wire up favicons and fix Vercel build

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,22 +2,20 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#3c4532" />
     <meta
       name="description"
       content="Benchlot - Tool rental marketplace"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Mulish:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Benchlot",
+  "short_name": "Benchlot",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#3c4532",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/src/components/SellerDashboardPage.js
+++ b/src/components/SellerDashboardPage.js
@@ -78,8 +78,6 @@ const SellerDashboardPage = () => {
   const [sellerBalance, setSellerBalance] = useState({ available: 0, pending: 0 });
   const [transfers, setTransfers] = useState([]);
   const [sellerOrders, setSellerOrders] = useState([]);
-  const [earningsLoading, setEarningsLoading] = useState(false);
-  
   // Fetch seller status and data on mount
   useEffect(() => {
     const loadSellerData = async () => {


### PR DESCRIPTION
## Summary
- Add Benchlot favicon and apple-touch-icon assets to public directory
- Wire up favicon links and webmanifest in `index.html`
- Remove unused `earningsLoading` state in `SellerDashboardPage` to fix Vercel build error
- Remove demo routes, implement guest checkout, and add seller email verification

## Test plan
- [ ] Verify favicon appears in browser tabs
- [ ] Confirm apple-touch-icon works on iOS home screen
- [ ] Verify Vercel build passes without errors
- [ ] Test guest checkout flow
- [ ] Test seller email verification flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)