### PR TITLE
Fix search bar swallowing spacebar on aggregator home

### DIFF
--- a/src/hooks/useAggregatorState.js
+++ b/src/hooks/useAggregatorState.js
@@ -46,7 +46,12 @@ function parseFromParams(params) {
 
 function serializeToParams(state) {
   const params = new URLSearchParams();
-  if (state.query && state.query.trim()) params.set('q', state.query.trim());
+  // Don't trim the value — the input is controlled by URL state, so trimming
+  // on every keystroke makes trailing spaces impossible (the space the user
+  // just typed gets stripped before it round-trips back into the input). We
+  // still gate on `.trim()` so a whitespace-only query doesn't pollute the
+  // URL with `?q=+++`.
+  if (state.query && state.query.trim()) params.set('q', state.query);
   for (const group of MULTI_GROUPS) {
     const g = state.filters?.[group];
     if (g && typeof g === 'object') {


### PR DESCRIPTION
## Summary
- Production bug: pressing space in the aggregator search bar did nothing.
- Root cause: the search input is controlled by URL state via `useAggregatorState`. Every keystroke round-tripped through `serializeToParams`, which called `.trim()` on the value before writing to the URL. Trailing spaces never made it back into the input, so `"hello" + space` snapped back to `"hello"` and the next character appended with no separator.
- Fix: pass the raw query to `params.set('q', state.query)` instead of `state.query.trim()`. Kept the `.trim()` in the predicate so whitespace-only queries still don't pollute the URL with `?q=+++`.

## Test plan
- [ ] Load `/`, type `stanley plane` in the search bar — both words appear with a space between them.
- [ ] Type a query, press space, then keep typing — space is preserved mid-word.
- [ ] Refresh on `?q=stanley+plane` — input shows `stanley plane`.
- [ ] Type only spaces — URL stays clean (no `?q=+++`).
- [ ] Clear the search via the X — input empties and refocuses, no leftover `q`.

https://claude.ai/code/session_01CaoVTyuKRrKZRF5afFyDp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaoVTyuKRrKZRF5afFyDp8)_