### PR TITLE
Add Michael Rouillard Antique Tools as a source

### DIFF
--- a/functions/alerts/sourceRegistry.js
+++ b/functions/alerts/sourceRegistry.js
@@ -17,6 +17,7 @@ const SOURCES = [
   { id: 'reddit', name: 'Reddit', shortName: 'Reddit' },
   { id: 'ebay', name: 'eBay', shortName: 'eBay' },
   { id: 'thebestthings', name: 'The Best Things', shortName: 'Best Things' },
+  { id: 'rouillard', name: 'Michael Rouillard Antique Tools', shortName: 'Rouillard' },
 ];
 
 const BY_ID = Object.fromEntries(SOURCES.map((s) => [s.id, s]));

--- a/functions/index.js
+++ b/functions/index.js
@@ -2679,6 +2679,36 @@ exports.onConversationMessageCreated = onDocumentCreated(
 );
 
 /**
+ * Scheduled ingestion — Michael Rouillard Antique Tools.
+ *
+ * Runs nightly at 03:55 UTC, between The Best Things (03:50) and Jim Bode
+ * (04:00). WooCommerce Store API source — small catalog (~130 active),
+ * paginates `/wp-json/wc/store/v1/products`, filters out anything not
+ * `is_in_stock`/`is_purchasable`, and lets `markExpired` handle products
+ * that disappear between runs.
+ */
+const { onSchedule } = require('firebase-functions/v2/scheduler');
+const rouillard = require('./ingest/rouillard');
+
+exports.scheduledIngestRouillard = onSchedule(
+  {
+    schedule: '55 3 * * *',
+    timeZone: 'Etc/UTC',
+    timeoutSeconds: 540,
+    memory: '512MiB',
+  },
+  async () => {
+    try {
+      const summary = await rouillard.runIngestion();
+      console.log('[scheduledIngestRouillard] done', summary);
+    } catch (err) {
+      console.error('[scheduledIngestRouillard] failed:', err.message, err.stack);
+      throw err;
+    }
+  }
+);
+
+/**
  * Scheduled ingestion — Jim Bode Tools Value Guide.
  *
  * First-ever scheduled function in this repo. Runs nightly at 04:00 UTC
@@ -2688,7 +2718,6 @@ exports.onConversationMessageCreated = onDocumentCreated(
  *
  * Can also be invoked locally via `node functions/ingest/run-jimbode.js`.
  */
-const { onSchedule } = require('firebase-functions/v2/scheduler');
 const jimbode = require('./ingest/jimbode');
 
 exports.scheduledIngestJimbode = onSchedule(

--- a/functions/ingest/SCHEMA.md
+++ b/functions/ingest/SCHEMA.md
@@ -80,7 +80,7 @@ The scraper preserves the untouched source payload so future normalizer versions
 |---|---|---|
 | `source` | string | Same as main listing. |
 | `source_id` | string | Same as main listing. |
-| `raw_format` | string | Discriminator. Current values: `"shopify_product"`, `"hyperkitten_item"`, `"sawmillcreek_thread"`, `"woodnet_thread"`, `"ebay_item_summary"`, `"thebestthings_item"`, `"reddit_post"`. |
+| `raw_format` | string | Discriminator. Current values: `"shopify_product"`, `"hyperkitten_item"`, `"sawmillcreek_thread"`, `"woodnet_thread"`, `"ebay_item_summary"`, `"thebestthings_item"`, `"reddit_post"`, `"woocommerce_product"`. |
 | `raw` | object | The full untouched source payload. Shape depends on `raw_format`. |
 | `scraped_at` | Timestamp | When this raw payload was captured. |
 
@@ -101,6 +101,7 @@ The scraper preserves the untouched source payload so future normalizer versions
 | `ebay` | eBay Carpentry & Woodworking (category 13870) | `ebay_item_summary` | M5 |
 | `thebestthings` | The Best Things (Bob Kaune) | `thebestthings_item` | post-launch |
 | `reddit` | Reddit (r/handtools, r/AntiqueToolBroker) | `reddit_post` | post-launch |
+| `rouillard` | Michael Rouillard Antique Tools | `woocommerce_product` | post-launch |
 
 Future sources register here and must respect the `(source, source_id)` ID convention.
 
@@ -167,3 +168,14 @@ Future sources register here and must respect the `(source, source_id)` ID conve
 - `posted_at` is always `null` (Hyperkitten doesn't expose per-item timestamps). `first_seen_at` is the recency signal.
 - `tags` include `hk_type:<code>` (the dealer's pre-classification) and `hk_new` (items carrying the visible NEW badge). The normalizer reads these as hints.
 - Books (`data-tool_type="B"`) are skipped at ingestion — Benchlot surfaces tools, not reference literature.
+
+### Michael Rouillard notes
+- `source_id` = WooCommerce product `slug` (e.g. `minty-hard-to-find-pair-of-left-right-leon-robbins-panel-raising-planes...`). Firestore docId: `rouillard__{slug}`.
+- `source_url` = WC `permalink` (`https://michaelrouillardtools.com/product/{slug}/`). Direct deep link.
+- `posted_at` is `null` — the WC Store API does not expose `date_created`. `first_seen_at` is the recency signal.
+- Data source: WooCommerce Store API at `/wp-json/wc/store/v1/products?per_page=100&page=N&orderby=date&order=desc`. Public, no auth, returns rich JSON (name, slug, permalink, description HTML, prices in minor units, images, categories, stock flags). Catalog is small (~130 active items).
+- Title decoding: the Store API emits HTML entities (`&#038;`, `&#8243;`, etc.) in `name` — `decodeEntities()` runs before heuristic matching and storage so `Brown & Sharpe` matches the brand list.
+- Sold/unavailable filter: skip when `is_in_stock === false` or `is_purchasable === false`. Defensive title/tag scan for `sold`/`reserved` markers in case a product is left flagged in-stock manually.
+- `tags` include the WooCommerce category slugs (`planes`, `wood-planes`, `modern-makers`, etc.) — the strongest categorization signal here, since native `tags` are typically empty. The M2 normalizer reads these as hints.
+- `condition_raw` is left null — Rouillard describes condition in prose ("Minty", "Fine", etc.) and the normalizer reads it from `description_raw`.
+- Standard `markExpired` sweep handles products that disappear (fully removed listings or stock flips not caught at fetch time).

--- a/functions/ingest/rouillard.js
+++ b/functions/ingest/rouillard.js
@@ -1,0 +1,244 @@
+/**
+ * Michael Rouillard Antique Tools ingestion adapter.
+ *
+ * Rouillard is a WooCommerce store on WordPress (NOT Shopify, despite a
+ * superficially similar shape). We pull from the WooCommerce Store API:
+ *
+ *   GET /wp-json/wc/store/v1/products?per_page=100&page=N
+ *
+ * The Store API returns only purchasable inventory by default — sold-out
+ * items remain visible but flip `is_in_stock`/`is_purchasable` to false.
+ * We filter those out at ingestion and let `markExpired` flip anything
+ * that disappears between runs (e.g. a fully removed product).
+ *
+ * Catalog is small (~130 active products as of 2026-05) and the endpoint
+ * is fast, so we do not need the Hyperkitten-style two-phase fetch.
+ */
+
+const axios = require('axios');
+const admin = require('firebase-admin');
+
+const { upsertListings, markExpired } = require('./externalListings');
+const { extractBrand, extractType } = require('./heuristics');
+
+const SOURCE = 'rouillard';
+const RAW_FORMAT = 'woocommerce_product';
+const STORE_ORIGIN = 'https://michaelrouillardtools.com';
+const BASE_URL = `${STORE_ORIGIN}/wp-json/wc/store/v1/products`;
+const PAGE_SIZE = 100;
+const PAGE_DELAY_MS = 1500;
+const REQUEST_TIMEOUT_MS = 20000;
+const USER_AGENT = 'Mozilla/5.0 (compatible; BenchlotIngestion/1.0; +https://benchlot.com)';
+
+const http = axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
+  headers: {
+    'User-Agent': USER_AGENT,
+    Accept: 'application/json',
+  },
+});
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// WC Store API returns titles with HTML entities (e.g. `&#038;` for `&`).
+// Decode the common cases so the heuristic brand/type matchers and downstream
+// LLM see plain text. Numeric entities cover the long tail (curly quotes,
+// em-dashes, etc.) the API emits.
+function decodeEntities(str) {
+  if (typeof str !== 'string') return '';
+  return str
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ');
+}
+
+// Store API quotes minor-unit integers as strings (e.g. `"88999"` for $889.99
+// when `currency_minor_unit: 2`). Parse defensively against the field's own
+// minor-unit declaration in case Rouillard ever switches currencies.
+function parsePriceToCents(prices) {
+  if (!prices || typeof prices !== 'object') return null;
+  const raw = prices.price;
+  if (raw === null || raw === undefined || raw === '') return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  const minorUnit = Number.isInteger(prices.currency_minor_unit) ? prices.currency_minor_unit : 2;
+  if (minorUnit === 2) return Math.round(n);
+  return Math.round(n * Math.pow(10, 2 - minorUnit));
+}
+
+function normalizeImages(imagesField) {
+  if (!Array.isArray(imagesField)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const img of imagesField) {
+    const src = img && typeof img.src === 'string' ? img.src : null;
+    if (!src || seen.has(src)) continue;
+    seen.add(src);
+    out.push(src);
+  }
+  return out;
+}
+
+// Tags = WC product tags + product category slugs. Categories are the
+// stronger signal here (e.g. `planes`, `wood-planes`, `modern-makers`) since
+// Rouillard's `tags` array is usually empty. Both feed the M2 normalizer.
+function buildTags(product) {
+  const seen = new Set();
+  const out = [];
+
+  const push = (val) => {
+    if (typeof val !== 'string') return;
+    const norm = val.trim().toLowerCase();
+    if (!norm || seen.has(norm)) return;
+    seen.add(norm);
+    out.push(norm);
+  };
+
+  if (Array.isArray(product.tags)) {
+    for (const t of product.tags) {
+      push(typeof t === 'string' ? t : t?.slug || t?.name);
+    }
+  }
+  if (Array.isArray(product.categories)) {
+    for (const c of product.categories) {
+      push(c?.slug);
+    }
+  }
+  return out;
+}
+
+/**
+ * Skip products that aren't currently buyable. Store API exposes both
+ * `is_in_stock` and `is_purchasable` — either being false should drop the
+ * row. Defensive title/tag scan covers the rare case where a sold item is
+ * left "in stock" with a manual marker.
+ */
+function isAvailable(product) {
+  if (!product) return false;
+  if (product.is_purchasable === false) return false;
+  if (product.is_in_stock === false) return false;
+
+  const title = decodeEntities(product.name || '');
+  if (/\b(sold|reserved)\b/i.test(title)) return false;
+
+  const tags = Array.isArray(product.tags) ? product.tags : [];
+  if (tags.some((t) => {
+    const s = typeof t === 'string' ? t : t?.slug || t?.name || '';
+    return /\b(sold|reserved)\b/i.test(s);
+  })) return false;
+
+  return true;
+}
+
+function toRecord(product) {
+  const slug = product.slug;
+  if (!slug) return null;
+  if (!isAvailable(product)) return null;
+
+  const title = decodeEntities(product.name || '');
+  const price_cents = parsePriceToCents(product.prices);
+
+  const listing = {
+    source: SOURCE,
+    source_id: slug,
+    source_url: typeof product.permalink === 'string' && product.permalink
+      ? product.permalink
+      : `${STORE_ORIGIN}/product/${slug}/`,
+    title_raw: title,
+    description_raw: product.description || null,
+    price_cents,
+    currency: product.prices?.currency_code || 'USD',
+    condition_raw: null,
+    images: normalizeImages(product.images),
+    posted_at: null, // Store API does not expose product creation date
+    tags: buildTags(product),
+    heuristic_brand: extractBrand(title),
+    heuristic_type: extractType(title),
+    canonical_brand: null,
+    canonical_type: null,
+    canonical_model: null,
+    canonical_size: null,
+    era_estimate: null,
+  };
+
+  return {
+    listing,
+    raw: product,
+    raw_format: RAW_FORMAT,
+  };
+}
+
+async function fetchPage(page) {
+  const url = `${BASE_URL}?per_page=${PAGE_SIZE}&page=${page}&orderby=date&order=desc`;
+  const resp = await http.get(url);
+  return Array.isArray(resp.data) ? resp.data : [];
+}
+
+async function scrapeAll(opts = {}) {
+  const maxPages = opts.maxPages ?? Infinity;
+  const records = [];
+  let page = 1;
+
+  while (page <= maxPages) {
+    if (page > 1) await sleep(PAGE_DELAY_MS);
+    let products;
+    try {
+      products = await fetchPage(page);
+    } catch (err) {
+      // The Store API returns `rest_post_invalid_page_number` (HTTP 400) when
+      // you request a page past the end. Treat that as a normal end-of-feed.
+      const status = err.response?.status;
+      const code = err.response?.data?.code;
+      if (status === 400 && code === 'rest_post_invalid_page_number') break;
+      console.error(`[rouillard] page ${page} failed: ${err.message}`);
+      throw err;
+    }
+    if (products.length === 0) break;
+
+    for (const product of products) {
+      const rec = toRecord(product);
+      if (rec) records.push(rec);
+    }
+
+    if (products.length < PAGE_SIZE) break;
+    page += 1;
+  }
+
+  return records;
+}
+
+async function runIngestion(opts = {}) {
+  const runStartedAt = admin.firestore.Timestamp.now();
+  const t0 = Date.now();
+
+  const records = await scrapeAll(opts);
+  const upsertSummary = await upsertListings(records, runStartedAt);
+  const expireSummary = await markExpired(SOURCE, runStartedAt);
+
+  return {
+    source: SOURCE,
+    scraped: records.length,
+    inserted: upsertSummary.inserted,
+    updated: upsertSummary.updated,
+    expired: expireSummary.expired,
+    durationMs: Date.now() - t0,
+    runStartedAt: runStartedAt.toDate(),
+  };
+}
+
+module.exports = {
+  SOURCE,
+  RAW_FORMAT,
+  runIngestion,
+  scrapeAll,
+  toRecord,
+  isAvailable,
+  decodeEntities,
+};

--- a/src/firebase/adapters/sources.js
+++ b/src/firebase/adapters/sources.js
@@ -97,6 +97,15 @@ const SOURCES = [
     indexed: true,
   },
   {
+    id: 'rouillard',
+    name: 'Michael Rouillard Antique Tools',
+    shortName: 'Rouillard',
+    kind: 'Dealer',
+    descriptor: 'Dealer · Antique · Since 1994',
+    homeUrl: 'https://michaelrouillardtools.com',
+    indexed: true,
+  },
+  {
     id: 'fbmarketplace',
     name: 'Facebook Marketplace',
     shortName: 'FB Marketplace',


### PR DESCRIPTION
## Summary
- Adds Michael Rouillard Antique Tools (`rouillard`) as a 7th aggregator source — small antique-tool dealer catalog (~131 active items).
- Pulls from the WooCommerce Store API (`/wp-json/wc/store/v1/products`). The site is WordPress + WooCommerce, not Shopify.
- Scheduled nightly at 03:55 UTC, between The Best Things (03:50) and Jim Bode (04:00), ahead of the alert matcher at 04:15.

## Implementation notes
- `source_id` = WC product `slug`; `source_url` = `permalink`.
- `price_cents` parsed from `prices.price` against the field's own `currency_minor_unit` declaration.
- HTML entities decoded in `name` before heuristic matching and storage so titles like `Brown &#038; Sharpe 14&#8243;` round-trip as `Brown & Sharpe 14″`.
- Drops products where `is_in_stock` or `is_purchasable` is false; defensive title/tag scan covers sold/reserved markers left in stock manually.
- Tags carry WC category slugs (`planes`, `wood-planes`, `modern-makers`, etc.) — the strongest categorization signal here since native WC tags are typically empty.
- `posted_at` is null (WC Store API doesn't expose product creation date); `first_seen_at` is the recency signal.
- Standard `markExpired` sweep handles products that disappear between runs.

## Test plan
- [x] Live-API smoke test: 131 records returned, matches `x-wp-total` exactly. All have prices and images.
- [x] Heuristic classification spot-check: 20 distinct brands, 24 distinct tool types (Bench Plane: 31, Chisel: 15, Block Plane: 9, Level: 8, Square: 6, etc.).
- [x] Entity decode: `Brown &#038; Sharpe 14&#8243; Saw` → `Brown & Sharpe 14″ Saw`.
- [ ] Real Firestore run via `node functions/ingest/run-rouillard.js --dry-run` then full run.
- [ ] Confirm scheduled function deploys cleanly.
- [ ] Verify Rouillard listings appear in the aggregator UI with the source filter chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)