### PR TITLE
Add Vintage Vials as a source

### DIFF
--- a/functions/alerts/sourceRegistry.js
+++ b/functions/alerts/sourceRegistry.js
@@ -18,6 +18,7 @@ const SOURCES = [
   { id: 'ebay', name: 'eBay', shortName: 'eBay' },
   { id: 'thebestthings', name: 'The Best Things', shortName: 'Best Things' },
   { id: 'rouillard', name: 'Michael Rouillard Antique Tools', shortName: 'Rouillard' },
+  { id: 'vintagevials', name: 'Vintage Vials', shortName: 'Vintage Vials' },
 ];
 
 const BY_ID = Object.fromEntries(SOURCES.map((s) => [s.id, s]));

--- a/functions/index.js
+++ b/functions/index.js
@@ -2739,6 +2739,36 @@ exports.scheduledIngestJimbode = onSchedule(
 );
 
 /**
+ * Scheduled ingestion — Vintage Vials Antique Tools.
+ *
+ * Runs nightly at 04:05 UTC, between Jim Bode (04:00) and the alert matcher
+ * (04:15). WooCommerce Store API source, same shape as Rouillard — paginates
+ * `/wp-json/wc/store/v1/products`, filters out anything not `is_in_stock`/
+ * `is_purchasable`, and lets `markExpired` handle products that disappear
+ * between runs. Catalog ~1,468 active items, mostly antique rules / levels /
+ * planes.
+ */
+const vintagevials = require('./ingest/vintagevials');
+
+exports.scheduledIngestVintagevials = onSchedule(
+  {
+    schedule: '5 4 * * *',
+    timeZone: 'Etc/UTC',
+    timeoutSeconds: 540,
+    memory: '512MiB',
+  },
+  async () => {
+    try {
+      const summary = await vintagevials.runIngestion();
+      console.log('[scheduledIngestVintagevials] done', summary);
+    } catch (err) {
+      console.error('[scheduledIngestVintagevials] failed:', err.message, err.stack);
+      throw err;
+    }
+  }
+);
+
+/**
  * Scheduled ingestion — Hyperkitten Tool Company.
  *
  * Runs nightly at 03:45 UTC, before Jim Bode (04:00) and the alert matcher

--- a/functions/ingest/SCHEMA.md
+++ b/functions/ingest/SCHEMA.md
@@ -102,6 +102,7 @@ The scraper preserves the untouched source payload so future normalizer versions
 | `thebestthings` | The Best Things (Bob Kaune) | `thebestthings_item` | post-launch |
 | `reddit` | Reddit (r/handtools, r/AntiqueToolBroker) | `reddit_post` | post-launch |
 | `rouillard` | Michael Rouillard Antique Tools | `woocommerce_product` | post-launch |
+| `vintagevials` | Vintage Vials | `woocommerce_product` | post-launch |
 
 Future sources register here and must respect the `(source, source_id)` ID convention.
 
@@ -179,3 +180,10 @@ Future sources register here and must respect the `(source, source_id)` ID conve
 - `tags` include the WooCommerce category slugs (`planes`, `wood-planes`, `modern-makers`, etc.) — the strongest categorization signal here, since native `tags` are typically empty. The M2 normalizer reads these as hints.
 - `condition_raw` is left null — Rouillard describes condition in prose ("Minty", "Fine", etc.) and the normalizer reads it from `description_raw`.
 - Standard `markExpired` sweep handles products that disappear (fully removed listings or stock flips not caught at fetch time).
+
+### Vintage Vials notes
+- Same WooCommerce Store API integration as Rouillard — see that section for shared mechanics (`is_in_stock`/`is_purchasable` filter, entity decoding, category-slugs-as-tags, null `posted_at`, `markExpired` sweep).
+- `source_id` = WooCommerce product `slug`. Firestore docId: `vintagevials__{slug}`.
+- `source_url` = WC `permalink` (`https://shop.vintagevials.com/product/{slug}/`).
+- Catalog skews premium antique — strong specialty in measuring tools (rules, levels, inclinometers) plus planes / plow planes / marking gauges. ~170 active at first ingest. WC `x-wp-total` reports ~1,468 across the whole feed because Vintage Vials retains sold listings with `is_in_stock: false` rather than removing them; our `isAvailable` filter drops those at ingest, so the index only carries buyable inventory.
+- Cron slot: `5 4 * * *` UTC nightly, between Jim Bode (04:00) and the alert matcher (04:15).

--- a/functions/ingest/vintagevials.js
+++ b/functions/ingest/vintagevials.js
@@ -1,0 +1,221 @@
+/**
+ * Vintage Vials Antique Tools ingestion adapter.
+ *
+ * Vintage Vials is a WooCommerce store on WordPress, same shape as
+ * `rouillard.js` — paginate the public Store API, filter to in-stock /
+ * purchasable, upsert. Catalog skews premium antique with a strong
+ * specialty in measuring tools (rules, levels, inclinometers) plus planes
+ * and plow planes.
+ *
+ *   GET /wp-json/wc/store/v1/products?per_page=100&page=N
+ *
+ * Catalog size at first ingest (2026-05): ~1,468 active products.
+ */
+
+const axios = require('axios');
+const admin = require('firebase-admin');
+
+const { upsertListings, markExpired } = require('./externalListings');
+const { extractBrand, extractType } = require('./heuristics');
+
+const SOURCE = 'vintagevials';
+const RAW_FORMAT = 'woocommerce_product';
+const STORE_ORIGIN = 'https://shop.vintagevials.com';
+const BASE_URL = `${STORE_ORIGIN}/wp-json/wc/store/v1/products`;
+const PAGE_SIZE = 100;
+const PAGE_DELAY_MS = 1500;
+const REQUEST_TIMEOUT_MS = 20000;
+const USER_AGENT = 'Mozilla/5.0 (compatible; BenchlotIngestion/1.0; +https://benchlot.com)';
+
+const http = axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
+  headers: {
+    'User-Agent': USER_AGENT,
+    Accept: 'application/json',
+  },
+});
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// WC Store API returns titles with HTML entities (e.g. `&#038;` for `&`).
+// Decode the common cases so the heuristic brand/type matchers and downstream
+// LLM see plain text. Numeric entities cover the long tail (curly quotes,
+// em-dashes, etc.) the API emits.
+function decodeEntities(str) {
+  if (typeof str !== 'string') return '';
+  return str
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ');
+}
+
+function parsePriceToCents(prices) {
+  if (!prices || typeof prices !== 'object') return null;
+  const raw = prices.price;
+  if (raw === null || raw === undefined || raw === '') return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  const minorUnit = Number.isInteger(prices.currency_minor_unit) ? prices.currency_minor_unit : 2;
+  if (minorUnit === 2) return Math.round(n);
+  return Math.round(n * Math.pow(10, 2 - minorUnit));
+}
+
+function normalizeImages(imagesField) {
+  if (!Array.isArray(imagesField)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const img of imagesField) {
+    const src = img && typeof img.src === 'string' ? img.src : null;
+    if (!src || seen.has(src)) continue;
+    seen.add(src);
+    out.push(src);
+  }
+  return out;
+}
+
+function buildTags(product) {
+  const seen = new Set();
+  const out = [];
+  const push = (val) => {
+    if (typeof val !== 'string') return;
+    const norm = val.trim().toLowerCase();
+    if (!norm || seen.has(norm)) return;
+    seen.add(norm);
+    out.push(norm);
+  };
+  if (Array.isArray(product.tags)) {
+    for (const t of product.tags) push(typeof t === 'string' ? t : t?.slug || t?.name);
+  }
+  if (Array.isArray(product.categories)) {
+    for (const c of product.categories) push(c?.slug);
+  }
+  return out;
+}
+
+function isAvailable(product) {
+  if (!product) return false;
+  if (product.is_purchasable === false) return false;
+  if (product.is_in_stock === false) return false;
+
+  const title = decodeEntities(product.name || '');
+  if (/\b(sold|reserved)\b/i.test(title)) return false;
+
+  const tags = Array.isArray(product.tags) ? product.tags : [];
+  if (tags.some((t) => {
+    const s = typeof t === 'string' ? t : t?.slug || t?.name || '';
+    return /\b(sold|reserved)\b/i.test(s);
+  })) return false;
+
+  return true;
+}
+
+function toRecord(product) {
+  const slug = product.slug;
+  if (!slug) return null;
+  if (!isAvailable(product)) return null;
+
+  const title = decodeEntities(product.name || '');
+  const price_cents = parsePriceToCents(product.prices);
+
+  const listing = {
+    source: SOURCE,
+    source_id: slug,
+    source_url: typeof product.permalink === 'string' && product.permalink
+      ? product.permalink
+      : `${STORE_ORIGIN}/product/${slug}/`,
+    title_raw: title,
+    description_raw: product.description || null,
+    price_cents,
+    currency: product.prices?.currency_code || 'USD',
+    condition_raw: null,
+    images: normalizeImages(product.images),
+    posted_at: null,
+    tags: buildTags(product),
+    heuristic_brand: extractBrand(title),
+    heuristic_type: extractType(title),
+    canonical_brand: null,
+    canonical_type: null,
+    canonical_model: null,
+    canonical_size: null,
+    era_estimate: null,
+  };
+
+  return {
+    listing,
+    raw: product,
+    raw_format: RAW_FORMAT,
+  };
+}
+
+async function fetchPage(page) {
+  const url = `${BASE_URL}?per_page=${PAGE_SIZE}&page=${page}&orderby=date&order=desc`;
+  const resp = await http.get(url);
+  return Array.isArray(resp.data) ? resp.data : [];
+}
+
+async function scrapeAll(opts = {}) {
+  const maxPages = opts.maxPages ?? Infinity;
+  const records = [];
+  let page = 1;
+
+  while (page <= maxPages) {
+    if (page > 1) await sleep(PAGE_DELAY_MS);
+    let products;
+    try {
+      products = await fetchPage(page);
+    } catch (err) {
+      const status = err.response?.status;
+      const code = err.response?.data?.code;
+      if (status === 400 && code === 'rest_post_invalid_page_number') break;
+      console.error(`[vintagevials] page ${page} failed: ${err.message}`);
+      throw err;
+    }
+    if (products.length === 0) break;
+
+    for (const product of products) {
+      const rec = toRecord(product);
+      if (rec) records.push(rec);
+    }
+
+    if (products.length < PAGE_SIZE) break;
+    page += 1;
+  }
+
+  return records;
+}
+
+async function runIngestion(opts = {}) {
+  const runStartedAt = admin.firestore.Timestamp.now();
+  const t0 = Date.now();
+
+  const records = await scrapeAll(opts);
+  const upsertSummary = await upsertListings(records, runStartedAt);
+  const expireSummary = await markExpired(SOURCE, runStartedAt);
+
+  return {
+    source: SOURCE,
+    scraped: records.length,
+    inserted: upsertSummary.inserted,
+    updated: upsertSummary.updated,
+    expired: expireSummary.expired,
+    durationMs: Date.now() - t0,
+    runStartedAt: runStartedAt.toDate(),
+  };
+}
+
+module.exports = {
+  SOURCE,
+  RAW_FORMAT,
+  runIngestion,
+  scrapeAll,
+  toRecord,
+  isAvailable,
+  decodeEntities,
+};

--- a/src/Pages/FAQPage.js
+++ b/src/Pages/FAQPage.js
@@ -48,7 +48,7 @@ const QUESTIONS = [
   },
   {
     q: 'What sources do you index?',
-    a: <>Jim Bode Tools, Hyperkitten, The Best Things, Michael Rouillard Antique Tools, Sawmill Creek, Woodnet, Reddit (r/handtools, r/AntiqueToolBroker), eBay, Facebook Marketplace. More on the way.</>,
+    a: <>Jim Bode Tools, Hyperkitten, The Best Things, Michael Rouillard Antique Tools, Vintage Vials, Sawmill Creek, Woodnet, Reddit (r/handtools, r/AntiqueToolBroker), eBay, Facebook Marketplace. More on the way.</>,
   },
   {
     q: "What's an alert?",

--- a/src/firebase/adapters/sources.js
+++ b/src/firebase/adapters/sources.js
@@ -106,6 +106,15 @@ const SOURCES = [
     indexed: true,
   },
   {
+    id: 'vintagevials',
+    name: 'Vintage Vials',
+    shortName: 'Vintage Vials',
+    kind: 'Dealer',
+    descriptor: 'Dealer · Antique · Rules & planes',
+    homeUrl: 'https://shop.vintagevials.com',
+    indexed: true,
+  },
+  {
     id: 'fbmarketplace',
     name: 'Facebook Marketplace',
     shortName: 'FB Marketplace',


### PR DESCRIPTION
## Summary
- Adds Vintage Vials (`vintagevials`) as an 8th aggregator source — a premium antique-tool dealer specializing in rules, levels, inclinometers, planes, and plow planes.
- Surfaced via the r/handtools thread where Consistent-Key-1490 recommended it (and two other sites we recon'd; the others land later).
- WooCommerce Store API source — adapter is a close port of `rouillard.js`. Cron at 04:05 UTC, between Jim Bode (04:00) and the alert matcher (04:15).

## Implementation notes
- Sold listings live in the same `/products` feed with `is_in_stock: false`, unlike Rouillard's separate `/sold-items/` archive. Our standard `isAvailable` filter drops them at ingest.
- `x-wp-total` reports ~1,468 but only **~170 are actually buyable** at any time. SCHEMA.md documents this so the next reader doesn't expect Rouillard-style 1:1 numbers.
- I considered extracting a shared `woocommerce.js` helper since this is the second WC source, but two isn't enough to justify the abstraction. If we add a third (Reddit's three-site recon found at least one more candidate), refactor then.

## Test plan
- [x] Live-API smoke test: 170 records, 100% with price + image.
- [x] Heuristic classification spot-check — top types: Level (46), Bench Plane (28), Rule (14), Plow Plane (10). Matches the dealer's specialty.
- [x] HTML entity decode confirmed via `Awesome JO. FULLER 18th Century Yellow Birch Plow Plane – Revolutionary War Officer` (en-dash + curly punctuation round-trip cleanly).
- [ ] First Firestore run (manual via `run-vintagevials.js` after merge).
- [ ] Confirm scheduled function deploys cleanly.
- [ ] Verify the Vintage Vials chip + listings appear in the aggregator UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)