### PR TITLE
Add OldTools.com as a source

### DIFF
--- a/functions/alerts/sourceRegistry.js
+++ b/functions/alerts/sourceRegistry.js
@@ -19,6 +19,7 @@ const SOURCES = [
   { id: 'thebestthings', name: 'The Best Things', shortName: 'Best Things' },
   { id: 'rouillard', name: 'Michael Rouillard Antique Tools', shortName: 'Rouillard' },
   { id: 'vintagevials', name: 'Vintage Vials', shortName: 'Vintage Vials' },
+  { id: 'oldtools', name: 'OldTools.com', shortName: 'OldTools' },
 ];
 
 const BY_ID = Object.fromEntries(SOURCES.map((s) => [s.id, s]));

--- a/functions/index.js
+++ b/functions/index.js
@@ -2739,6 +2739,38 @@ exports.scheduledIngestJimbode = onSchedule(
 );
 
 /**
+ * Scheduled ingestion — OldTools.com.
+ *
+ * Runs nightly at 02:45 UTC. Deliberately off-band (the rest of the source
+ * crons cluster 03:00–04:05): oldtools' catalog is small (~200 items) and
+ * slow-moving (sitemap lastmods range to 2018), so the staleness window
+ * before the alert matcher at 04:15 doesn't matter, and the wider margin
+ * absorbs the per-item fetch loop comfortably.
+ *
+ * Strategy: pull `/shop/sitemap/sitemap-items-1.xml`, then fetch each
+ * item URL and parse Schema.org Product microdata.
+ */
+const oldtools = require('./ingest/oldtools');
+
+exports.scheduledIngestOldtools = onSchedule(
+  {
+    schedule: '45 2 * * *',
+    timeZone: 'Etc/UTC',
+    timeoutSeconds: 540,
+    memory: '512MiB',
+  },
+  async () => {
+    try {
+      const summary = await oldtools.runIngestion();
+      console.log('[scheduledIngestOldtools] done', summary);
+    } catch (err) {
+      console.error('[scheduledIngestOldtools] failed:', err.message, err.stack);
+      throw err;
+    }
+  }
+);
+
+/**
  * Scheduled ingestion — Vintage Vials Antique Tools.
  *
  * Runs nightly at 04:05 UTC, between Jim Bode (04:00) and the alert matcher

--- a/functions/ingest/SCHEMA.md
+++ b/functions/ingest/SCHEMA.md
@@ -80,7 +80,7 @@ The scraper preserves the untouched source payload so future normalizer versions
 |---|---|---|
 | `source` | string | Same as main listing. |
 | `source_id` | string | Same as main listing. |
-| `raw_format` | string | Discriminator. Current values: `"shopify_product"`, `"hyperkitten_item"`, `"sawmillcreek_thread"`, `"woodnet_thread"`, `"ebay_item_summary"`, `"thebestthings_item"`, `"reddit_post"`, `"woocommerce_product"`. |
+| `raw_format` | string | Discriminator. Current values: `"shopify_product"`, `"hyperkitten_item"`, `"sawmillcreek_thread"`, `"woodnet_thread"`, `"ebay_item_summary"`, `"thebestthings_item"`, `"reddit_post"`, `"woocommerce_product"`, `"oldtools_item"`. |
 | `raw` | object | The full untouched source payload. Shape depends on `raw_format`. |
 | `scraped_at` | Timestamp | When this raw payload was captured. |
 
@@ -103,6 +103,7 @@ The scraper preserves the untouched source payload so future normalizer versions
 | `reddit` | Reddit (r/handtools, r/AntiqueToolBroker) | `reddit_post` | post-launch |
 | `rouillard` | Michael Rouillard Antique Tools | `woocommerce_product` | post-launch |
 | `vintagevials` | Vintage Vials | `woocommerce_product` | post-launch |
+| `oldtools` | OldTools.com | `oldtools_item` | post-launch |
 
 Future sources register here and must respect the `(source, source_id)` ID convention.
 
@@ -187,3 +188,14 @@ Future sources register here and must respect the `(source, source_id)` ID conve
 - `source_url` = WC `permalink` (`https://shop.vintagevials.com/product/{slug}/`).
 - Catalog skews premium antique — strong specialty in measuring tools (rules, levels, inclinometers) plus planes / plow planes / marking gauges. ~170 active at first ingest. WC `x-wp-total` reports ~1,468 across the whole feed because Vintage Vials retains sold listings with `is_in_stock: false` rather than removing them; our `isAvailable` filter drops those at ingest, so the index only carries buyable inventory.
 - Cron slot: `5 4 * * *` UTC nightly, between Jim Bode (04:00) and the alert matcher (04:15).
+
+### OldTools.com notes
+- `source_id` = item URL slug (e.g. `Keen-Kutter-Corner-Chisel-1-inch-2422`). Firestore docId: `oldtools__{slug}`. The trailing numeric id is stable but baked into the slug, so the slug alone is unique.
+- `source_url` = `https://www.oldtools.com/item/{slug}`.
+- `posted_at` is `null` — oldtools doesn't expose a per-item posted-at. Sitemap `lastmod` exists but reflects the page's last edit, not when the item was listed; `first_seen_at` remains the recency signal.
+- Data source: a single sitemap (`/shop/sitemap/sitemap-items-1.xml`, ~200 URLs) walked once per run; each item page is fetched and parsed with cheerio, pulling Schema.org Product microdata (`itemprop="name"`, `itemprop="price"`, `itemprop="description"`, etc.).
+- Two `itemprop="price"` values per page: the first is a hard-coded `0.00` placeholder, the second is the canonical Offer price. We take the max non-zero value.
+- `itemprop="brand"` is the seller's storefront brand ("Falcon-Wood"), NOT the tool brand — ignored at ingest. The heuristic brand matcher works the title.
+- Hero image preference: `og:image` (full-size) over `itemprop="image"` (thumbnail with `_th` suffix), since the latter is significantly worse on the card.
+- `tags` left empty for now — the categories sitemap exists but mapping requires per-category page scraping (deferred).
+- Cron slot: `45 2 * * *` UTC. Deliberately off-band from the 03:00–04:05 cluster — small, slow-moving catalog tolerates the staleness window, and the wider margin absorbs the ~5-minute per-item fetch loop comfortably.

--- a/functions/ingest/oldtools.js
+++ b/functions/ingest/oldtools.js
@@ -1,0 +1,235 @@
+/**
+ * OldTools.com ingestion adapter.
+ *
+ * Custom WordPress storefront (not Shopify, not WooCommerce) that publishes
+ * a sitemap index of every active item. The catalog is small and slow-moving
+ * (~200 items as of 2026-05; sitemap lastmods range back to 2018), so the
+ * scrape strategy is straightforward:
+ *
+ *   1. Fetch `/shop/sitemap/sitemap-items-1.xml`, pull `<loc>` URLs.
+ *   2. For each item URL, fetch the HTML and parse Schema.org Product
+ *      microdata (`itemprop="name"`, `itemprop="price"`, etc.).
+ *   3. Skip items with no real price (a 0.00 placeholder is hard-coded on
+ *      every page; the canonical Offer price appears as a second
+ *      `itemprop="price"` later in the document).
+ *   4. Standard `markExpired` flips items whose URLs drop from the sitemap.
+ *
+ * `itemprop="brand"` is the seller's storefront brand ("Falcon-Wood"),
+ * NOT the tool brand — we ignore it and let `extractBrand` work the title.
+ */
+
+const axios = require('axios');
+const cheerio = require('cheerio');
+const admin = require('firebase-admin');
+
+const { upsertListings, markExpired } = require('./externalListings');
+const { extractBrand, extractType } = require('./heuristics');
+
+const SOURCE = 'oldtools';
+const RAW_FORMAT = 'oldtools_item';
+const STORE_ORIGIN = 'https://www.oldtools.com';
+const SITEMAP_URL = `${STORE_ORIGIN}/shop/sitemap/sitemap-items-1.xml`;
+const ITEM_DELAY_MS = 500;
+const REQUEST_TIMEOUT_MS = 20000;
+const MAX_DESCRIPTION_CHARS = 5000;
+const USER_AGENT = 'Mozilla/5.0 (compatible; BenchlotIngestion/1.0; +https://benchlot.com)';
+
+const http = axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
+  headers: {
+    'User-Agent': USER_AGENT,
+    Accept: 'text/html,application/xhtml+xml,application/xml',
+  },
+});
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// Sitemap URLs end in `/item/<slug-with-trailing-id>`. The trailing id is
+// stable across renames, but using the full slug keeps the docId
+// human-readable and matches the Rouillard convention.
+function extractSlug(url) {
+  const m = String(url || '').match(/\/item\/([^/?#]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+async function fetchSitemapUrls() {
+  const resp = await http.get(SITEMAP_URL);
+  const xml = typeof resp.data === 'string' ? resp.data : '';
+  if (!xml) throw new Error('[oldtools] empty sitemap response');
+  const $ = cheerio.load(xml, { xmlMode: true });
+  const urls = [];
+  $('url > loc').each((_, el) => {
+    const u = $(el).text().trim();
+    if (u && /\/item\//.test(u)) urls.push(u);
+  });
+  return urls;
+}
+
+// `itemprop="price" content="0.00"` is rendered on every page as a
+// placeholder, followed later by the real Offer price. Take the maximum of
+// all parsed prices — handles both the placeholder case and any future
+// page that drops the placeholder.
+function parsePriceCents($) {
+  const candidates = [];
+  $('[itemprop="price"]').each((_, el) => {
+    const raw = $(el).attr('content') ?? $(el).text();
+    const n = Number(String(raw || '').trim());
+    if (Number.isFinite(n) && n > 0) candidates.push(n);
+  });
+  if (candidates.length === 0) return null;
+  return Math.round(Math.max(...candidates) * 100);
+}
+
+function parseImages($) {
+  const seen = new Set();
+  const out = [];
+  const push = (src) => {
+    if (typeof src !== 'string') return;
+    const trimmed = src.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    out.push(trimmed);
+  };
+
+  // Prefer the og:image (full-size) over the itemprop="image" thumbnail
+  // (`_th` suffix on oldtools.com — significantly worse for the card hero).
+  const og = $('meta[property="og:image"]').attr('content');
+  if (og) push(og);
+  $('[itemprop="image"]').each((_, el) => {
+    push($(el).attr('content') || $(el).attr('src'));
+  });
+  return out;
+}
+
+function parseDescription($) {
+  const raw = $('[itemprop="description"]').attr('content')
+    || $('[itemprop="description"]').first().text();
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, MAX_DESCRIPTION_CHARS);
+}
+
+function parseTitle($) {
+  // Two reasonable sources — the visible h1 and the microdata `name`. The
+  // h1 is usually cleaner; fall through if it's missing for any reason.
+  const h1 = $('h1.itemName').first().text().trim();
+  if (h1) return h1;
+  const meta = $('[itemprop="name"]').attr('content') || $('[itemprop="name"]').first().text();
+  return (meta || '').trim();
+}
+
+function parseCurrency($) {
+  const cur = $('[itemprop="priceCurrency"]').first().attr('content');
+  return (cur || '').trim() || 'USD';
+}
+
+function buildRecord(url, html) {
+  const slug = extractSlug(url);
+  if (!slug) return null;
+
+  const $ = cheerio.load(html);
+  const title = parseTitle($);
+  if (!title) return null;
+
+  const price_cents = parsePriceCents($);
+  if (price_cents === null) return null; // sold / unpriced — skip
+
+  const listing = {
+    source: SOURCE,
+    source_id: slug,
+    source_url: url,
+    title_raw: title,
+    description_raw: parseDescription($),
+    price_cents,
+    currency: parseCurrency($),
+    condition_raw: null,
+    images: parseImages($),
+    posted_at: null, // oldtools doesn't expose a per-item posted-at
+    tags: [],
+    heuristic_brand: extractBrand(title),
+    heuristic_type: extractType(title),
+    canonical_brand: null,
+    canonical_type: null,
+    canonical_model: null,
+    canonical_size: null,
+    era_estimate: null,
+  };
+
+  // Preserve a compact raw payload for re-normalization. Storing the full
+  // 150KB HTML page would balloon Firestore — pull just the structured
+  // bits that the normalizer needs.
+  const raw = {
+    url,
+    title,
+    description_raw: listing.description_raw,
+    price_cents,
+    currency: listing.currency,
+    images: listing.images,
+    sku: $('[itemprop="sku"]').first().attr('content') || null,
+    mpn: $('[itemprop="mpn"]').first().attr('content') || null,
+    productID: $('[itemprop="productID"]').first().attr('content') || null,
+  };
+
+  return { listing, raw, raw_format: RAW_FORMAT };
+}
+
+async function fetchItem(url) {
+  const resp = await http.get(url);
+  const html = typeof resp.data === 'string' ? resp.data : '';
+  if (!html) throw new Error(`[oldtools] empty item response for ${url}`);
+  return html;
+}
+
+async function scrapeAll(opts = {}) {
+  const maxItems = opts.maxItems ?? Infinity;
+  const urls = await fetchSitemapUrls();
+  if (urls.length === 0) {
+    console.warn('[oldtools] sitemap returned 0 item URLs — nothing to scrape');
+    return [];
+  }
+  const records = [];
+  const limit = Math.min(urls.length, maxItems);
+  for (let i = 0; i < limit; i++) {
+    if (i > 0) await sleep(ITEM_DELAY_MS);
+    const url = urls[i];
+    try {
+      const html = await fetchItem(url);
+      const rec = buildRecord(url, html);
+      if (rec) records.push(rec);
+    } catch (err) {
+      console.warn(`[oldtools] item ${url} failed: ${err.message}`);
+    }
+  }
+  return records;
+}
+
+async function runIngestion(opts = {}) {
+  const runStartedAt = admin.firestore.Timestamp.now();
+  const t0 = Date.now();
+
+  const records = await scrapeAll(opts);
+  const upsertSummary = await upsertListings(records, runStartedAt);
+  const expireSummary = await markExpired(SOURCE, runStartedAt);
+
+  return {
+    source: SOURCE,
+    scraped: records.length,
+    inserted: upsertSummary.inserted,
+    updated: upsertSummary.updated,
+    expired: expireSummary.expired,
+    durationMs: Date.now() - t0,
+    runStartedAt: runStartedAt.toDate(),
+  };
+}
+
+module.exports = {
+  SOURCE,
+  RAW_FORMAT,
+  runIngestion,
+  scrapeAll,
+  buildRecord,
+  fetchSitemapUrls,
+};

--- a/src/Pages/FAQPage.js
+++ b/src/Pages/FAQPage.js
@@ -48,7 +48,7 @@ const QUESTIONS = [
   },
   {
     q: 'What sources do you index?',
-    a: <>Jim Bode Tools, Hyperkitten, The Best Things, Michael Rouillard Antique Tools, Vintage Vials, Sawmill Creek, Woodnet, Reddit (r/handtools, r/AntiqueToolBroker), eBay, Facebook Marketplace. More on the way.</>,
+    a: <>Jim Bode Tools, Hyperkitten, The Best Things, Michael Rouillard Antique Tools, Vintage Vials, OldTools.com, Sawmill Creek, Woodnet, Reddit (r/handtools, r/AntiqueToolBroker), eBay, Facebook Marketplace. More on the way.</>,
   },
   {
     q: "What's an alert?",

--- a/src/firebase/adapters/sources.js
+++ b/src/firebase/adapters/sources.js
@@ -115,6 +115,15 @@ const SOURCES = [
     indexed: true,
   },
   {
+    id: 'oldtools',
+    name: 'OldTools.com',
+    shortName: 'OldTools',
+    kind: 'Dealer',
+    descriptor: 'Dealer · Antique woodworking',
+    homeUrl: 'https://www.oldtools.com/shop',
+    indexed: true,
+  },
+  {
     id: 'fbmarketplace',
     name: 'Facebook Marketplace',
     shortName: 'FB Marketplace',


### PR DESCRIPTION
## Summary
- Adds OldTools.com (`oldtools`) as a 9th aggregator source — antique woodworking dealer with ~200 active items.
- Surfaced from the r/handtools recon (alongside vintagevials and vintagewoodworkingtools).
- Custom WordPress storefront — no API. Sitemap-walker + per-item HTML scrape via cheerio, parsing Schema.org Product microdata.

## Implementation notes
- `source_id` = full URL slug (e.g. `Keen-Kutter-Corner-Chisel-1-inch-2422`). Trailing numeric id is baked in, so the slug alone is unique.
- Two `itemprop="price"` values per page: a `0.00` placeholder followed by the canonical Offer price. Take the max non-zero.
- `itemprop="brand"` is the seller's storefront brand ("Falcon-Wood"), not the tool brand. Ignored at ingest; heuristics work the title.
- Hero image preference: `og:image` (full size) over `itemprop="image"` (`_th` thumbnail).
- Raw payload stored as structured fields only — full HTML pages are 150KB and would balloon Firestore.
- Cron at 02:45 UTC, deliberately off-band from the 03:00–04:05 cluster. Catalog tolerates the staleness window because items move slowly.

## Test plan
- [x] Live smoke test: 195/197 sitemap URLs produced valid records (the 2 dropped had no real price = sold/unpriced).
- [x] Brand heuristics matching: Stanley (34), Preston (7), Starrett (5), Millers Falls (3). 123 Unknown is expected — oldtools titles often omit the brand for unmarked antiques.
- [x] Image hero is full-size, not thumbnail.
- [ ] First Firestore run (manual via `run-oldtools.js`).
- [ ] Confirm scheduled function deploys cleanly.
- [ ] Verify the OldTools chip appears in the aggregator UI with correct count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)