### PR TITLE
Location filter PR 3/3: UI + alerts

### DIFF
--- a/functions/alerts/matcher.js
+++ b/functions/alerts/matcher.js
@@ -42,7 +42,7 @@ function alertToUrl(alert) {
   const params = new URLSearchParams();
   if (alert.query && alert.query.trim()) params.set('q', alert.query.trim());
   const filters = alert.filters || {};
-  for (const group of ['cat', 'maker', 'cond', 'src']) {
+  for (const group of ['cat', 'maker', 'cond', 'src', 'region']) {
     const g = filters[group];
     if (g && typeof g === 'object') {
       const keys = Object.keys(g).filter((k) => g[k]);
@@ -61,7 +61,7 @@ function summarizeAlert(alert) {
   const parts = [];
   if (alert.query && alert.query.trim()) parts.push(`"${alert.query.trim()}"`);
   const filters = alert.filters || {};
-  const activeGroups = ['cat', 'maker', 'cond', 'src'].filter((g) => {
+  const activeGroups = ['cat', 'maker', 'cond', 'src', 'region'].filter((g) => {
     const m = filters[g];
     return m && Object.values(m).some(Boolean);
   });

--- a/functions/alerts/predicates.js
+++ b/functions/alerts/predicates.js
@@ -5,6 +5,31 @@
  * out, so it's trivially testable.
  */
 
+// Census Bureau 4-region split (DC bucketed with South). Mirrored client-side
+// in `src/firebase/adapters/externalListingAdapter.js` — small + stable, no
+// shared util because the ESM/CJS divide makes that more trouble than it's
+// worth at our scale.
+const STATE_TO_REGION = {
+  CT: 'Northeast', ME: 'Northeast', MA: 'Northeast', NH: 'Northeast',
+  NJ: 'Northeast', NY: 'Northeast', PA: 'Northeast', RI: 'Northeast',
+  VT: 'Northeast',
+  IL: 'Midwest', IN: 'Midwest', IA: 'Midwest', KS: 'Midwest',
+  MI: 'Midwest', MN: 'Midwest', MO: 'Midwest', NE: 'Midwest',
+  ND: 'Midwest', OH: 'Midwest', SD: 'Midwest', WI: 'Midwest',
+  AL: 'South', AR: 'South', DE: 'South', DC: 'South', FL: 'South',
+  GA: 'South', KY: 'South', LA: 'South', MD: 'South', MS: 'South',
+  NC: 'South', OK: 'South', SC: 'South', TN: 'South', TX: 'South',
+  VA: 'South', WV: 'South',
+  AK: 'West', AZ: 'West', CA: 'West', CO: 'West', HI: 'West',
+  ID: 'West', MT: 'West', NV: 'West', NM: 'West', OR: 'West',
+  UT: 'West', WA: 'West', WY: 'West',
+};
+
+function regionForState(state) {
+  if (!state) return 'Other';
+  return STATE_TO_REGION[state] || 'Other';
+}
+
 function normQuery(q) {
   return (q || '').trim().toLowerCase();
 }
@@ -91,6 +116,13 @@ function matchesAlert(listing, alert) {
   if (!multiMatch(filters.src, listing.source)) return false;
   if (!ageMatches(listing, filters.age)) return false;
   if (!priceMatches(listing, filters.price)) return false;
+  // Region: derive from listing.location_state. eBay listings have no state
+  // and are dropped when any region filter is active — same convention as
+  // the client-side filter so alerts and search results stay consistent.
+  if (filters.region && Object.keys(filters.region).length > 0) {
+    if (listing.source === 'ebay') return false;
+    if (!multiMatch(filters.region, regionForState(listing.location_state))) return false;
+  }
 
   return true;
 }

--- a/src/Pages/aggregator/AlertsPage.jsx
+++ b/src/Pages/aggregator/AlertsPage.jsx
@@ -44,7 +44,7 @@ function alertToParams(alert) {
   const params = new URLSearchParams();
   if (alert.query && alert.query.trim()) params.set('q', alert.query.trim());
   const filters = alert.filters || {};
-  for (const group of ['cat', 'maker', 'cond', 'src']) {
+  for (const group of ['cat', 'maker', 'cond', 'src', 'region']) {
     const g = filters[group];
     if (g && typeof g === 'object') {
       const keys = Object.keys(g).filter((k) => g[k]);

--- a/src/Pages/aggregator/ResultsState.jsx
+++ b/src/Pages/aggregator/ResultsState.jsx
@@ -39,6 +39,7 @@ const CHIP_GROUP_PREFIX = {
   cond: 'Condition',
   src: 'Source',
   price: 'Price',
+  region: 'Ships from',
 };
 
 /**
@@ -122,6 +123,14 @@ function filterLocally(raw, state) {
     }
     if (filters?.cond && !filters.cond[l.condition]) return false;
     if (filters?.src && l.source && !filters.src[l.source]) return false;
+    // Region filter — eBay is always dropped when a region is selected, since
+    // eBay v1 has no per-listing state data and would otherwise show up in
+    // every region by accident. Documented in SCHEMA.md and the FilterRail
+    // tooltip. eBay reappears the moment the user clears the region filter.
+    if (filters?.region && Object.keys(filters.region).length > 0) {
+      if (l.source === 'ebay') return false;
+      if (!filters.region[l.location_region]) return false;
+    }
     if (filters?.pics?.yes && !l.imageUrl) return false;
     const price = filters?.price;
     if (price) {

--- a/src/components/aggregator/FilterRail.jsx
+++ b/src/components/aggregator/FilterRail.jsx
@@ -20,6 +20,7 @@ import React, { useState, useMemo } from 'react';
 import { ChevronDown, SlidersHorizontal } from 'lucide-react';
 
 import { SOURCES } from '../../firebase/adapters/sources';
+import { REGIONS } from '../../firebase/adapters/externalListingAdapter';
 
 const EYEBROW = {
   fontFamily: "'Outfit', sans-serif",
@@ -322,7 +323,7 @@ const FilterRail = ({
   const hasAnyFilter = useMemo(() => {
     if (!filters) return false;
     if (filters.price && (filters.price.min != null || filters.price.max != null)) return true;
-    for (const group of ['cat', 'maker', 'cond', 'src', 'pics']) {
+    for (const group of ['cat', 'maker', 'cond', 'src', 'pics', 'region']) {
       if (filters[group] && Object.keys(filters[group]).length > 0) return true;
     }
     return false;
@@ -410,6 +411,24 @@ const FilterRail = ({
             />
           );
         })}
+      </CollapsibleGroup>
+
+      {/* Ships from — US-only v1. Region is derived at read time from the
+         per-listing `location_state` (dealer-tagged for the 6 dealers, regex-
+         parsed from FBM's "City, ST" string, bracket-parsed from forum/Reddit
+         titles). eBay listings carry no state in v1 (their item_summary API
+         doesn't expose it) so they're excluded from these counts and dropped
+         from results when any region chip is active — flagged in the suffix. */}
+      <CollapsibleGroup label="Ships from" suffix="excl. eBay" defaultOpen>
+        {REGIONS.map((region) => (
+          <CheckboxRow
+            key={region}
+            label={region}
+            count={facets?.region?.[region]}
+            checked={Boolean(filters?.region?.[region])}
+            onChange={() => toggleFilter('region', region)}
+          />
+        ))}
       </CollapsibleGroup>
 
       {/* Category — driven from live facets, count desc, top 12 + Show more.

--- a/src/firebase/adapters/aggregatorFacets.js
+++ b/src/firebase/adapters/aggregatorFacets.js
@@ -95,7 +95,7 @@ export async function getSourceCounts(sourceIds) {
  * option → count. Options with zero hits are omitted.
  */
 export function computeFacets(listings) {
-  const counts = { category: {}, maker: {}, source: {}, condition: {} };
+  const counts = { category: {}, maker: {}, source: {}, condition: {}, region: {} };
   if (!Array.isArray(listings)) return counts;
 
   for (const l of listings) {
@@ -112,6 +112,13 @@ export function computeFacets(listings) {
     }
     if (l.source) counts.source[l.source] = (counts.source[l.source] || 0) + 1;
     if (l.condition) counts.condition[l.condition] = (counts.condition[l.condition] || 0) + 1;
+    // Region facet — exclude eBay because every eBay listing carries null
+    // state in v1 (the Browse item_summary API doesn't expose location and
+    // per-item detail would 6500x quota). Including them would dump 17k+
+    // listings into "Other" and drown out the real per-region counts.
+    if (l.source !== 'ebay' && l.location_region) {
+      counts.region[l.location_region] = (counts.region[l.location_region] || 0) + 1;
+    }
   }
 
   return counts;

--- a/src/firebase/adapters/externalListingAdapter.js
+++ b/src/firebase/adapters/externalListingAdapter.js
@@ -26,6 +26,32 @@ import { SOURCES, sourceDisplayName } from './sources';
 const COLLECTION = 'externalListings';
 const DEFAULT_LIMIT = 60;
 
+// Census Bureau 4-region split (DC bucketed with South). Derived at read
+// time from `location_state` — never stored. Mirrored server-side in
+// `functions/alerts/predicates.js` for alert matching.
+const STATE_TO_REGION = {
+  CT: 'Northeast', ME: 'Northeast', MA: 'Northeast', NH: 'Northeast',
+  NJ: 'Northeast', NY: 'Northeast', PA: 'Northeast', RI: 'Northeast',
+  VT: 'Northeast',
+  IL: 'Midwest', IN: 'Midwest', IA: 'Midwest', KS: 'Midwest',
+  MI: 'Midwest', MN: 'Midwest', MO: 'Midwest', NE: 'Midwest',
+  ND: 'Midwest', OH: 'Midwest', SD: 'Midwest', WI: 'Midwest',
+  AL: 'South', AR: 'South', DE: 'South', DC: 'South', FL: 'South',
+  GA: 'South', KY: 'South', LA: 'South', MD: 'South', MS: 'South',
+  NC: 'South', OK: 'South', SC: 'South', TN: 'South', TX: 'South',
+  VA: 'South', WV: 'South',
+  AK: 'West', AZ: 'West', CA: 'West', CO: 'West', HI: 'West',
+  ID: 'West', MT: 'West', NV: 'West', NM: 'West', OR: 'West',
+  UT: 'West', WA: 'West', WY: 'West',
+};
+
+export const REGIONS = ['Northeast', 'Midwest', 'South', 'West', 'Other'];
+
+export function regionForState(state) {
+  if (!state) return 'Other';
+  return STATE_TO_REGION[state] || 'Other';
+}
+
 /**
  * Reshape one raw Firestore doc into a tool-card-compatible object.
  * Exported for tests and callers who already have the raw doc.
@@ -40,6 +66,14 @@ export function adaptExternalListing(docId, data) {
     typeof data.price_cents === 'number' ? data.price_cents / 100 : null;
   const imageUrl = Array.isArray(data.images) && data.images.length > 0 ? data.images[0] : null;
 
+  // Location: state is stored, region is derived. `listing.location` is
+  // populated for the existing MapPin UI on the card — falls back through
+  // display → state → null so a row with only a state code still renders.
+  const locationState = data.location_state || null;
+  const locationDisplay = data.location_display || null;
+  const locationRegion = regionForState(locationState);
+  const cardLocation = locationDisplay || locationState || null;
+
   return {
     id: docId,
     name: data.title_raw || '(untitled listing)',
@@ -49,6 +83,7 @@ export function adaptExternalListing(docId, data) {
     condition: data.condition_raw || null,
     imageUrl,
     images: Array.isArray(data.images) ? data.images.map((url) => ({ url })) : [],
+    location: cardLocation,
 
     // external-mode markers — ToolListingCard reads these when rendering.
     external: true,
@@ -56,6 +91,11 @@ export function adaptExternalListing(docId, data) {
     source_id: data.source_id,
     source_url: data.source_url,
     sourceName: sourceDisplayName(data.source),
+
+    // location fields — used by the region filter and card metadata
+    location_state: locationState,
+    location_region: locationRegion,
+    location_display: locationDisplay,
 
     // raw canonical fields preserved for downstream consumers (search, alerts).
     canonical_brand: data.canonical_brand || null,

--- a/src/hooks/useAggregatorState.js
+++ b/src/hooks/useAggregatorState.js
@@ -10,7 +10,7 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-const MULTI_GROUPS = ['cat', 'maker', 'cond', 'src', 'pics'];
+const MULTI_GROUPS = ['cat', 'maker', 'cond', 'src', 'pics', 'region'];
 
 // Some filter groups use opaque keys ("yes" for the pics toggle) where the
 // raw key isn't a great chip label. Map those here.


### PR DESCRIPTION
## Summary
Final PR of three for the US-only Ships-from filter. Surfaces the `location_state` ingested in PR 1 (#15) as a "Ships from" filter group and a state badge on each result card. Skipped the planned PR 2 backfill — re-running the 3 known-state dealer ingests after PR 1's deploy did the same thing.

## What's user-visible
- New "Ships from" section in the filter rail, between Source and Category.
- 5 chips: Northeast / Midwest / South / West / Other. Suffix "excl. eBay" — see caveat below.
- Each card now shows the location (city + state, or just state) via the existing MapPin slot when known.
- Saved alerts can now include a region filter and the deep-link URL round-trips it back.

## eBay caveat
The Buy Browse `item_summary` API doesn't expose per-item location, and per-item detail would multiply quota by 6500×. So eBay listings carry `location_state: null` in v1, which means:
1. **Region facet counts exclude eBay** — counts reflect what the filter can actually narrow.
2. **eBay is dropped from results when any region chip is active** — same convention applied to search and alerts so they stay consistent. Documented in SCHEMA.md.

When no region chip is active, eBay listings appear normally.

## Test plan
- [x] Production build compiles cleanly (+863 B gzipped).
- [x] eslint clean across all touched files.
- [ ] Local dev server: confirm "Ships from" group renders, chips toggle, URL updates to `?region=Northeast|West`, reload preserves selection.
- [ ] Confirm a card with `location_state: 'NY'` shows MapPin + "Lansing, NY" (Jim Bode example).
- [ ] Confirm a card with no `location_state` shows nothing in the location slot (no "null" or "Unknown").
- [ ] Save an alert with a region filter, verify the URL serializer reproduces it on AlertsPage and the deep-link reapplies the filter on `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)