### PR TITLE
Ships-from: 50 states instead of 4 regions

### DIFF
--- a/functions/alerts/matcher.js
+++ b/functions/alerts/matcher.js
@@ -42,7 +42,7 @@ function alertToUrl(alert) {
   const params = new URLSearchParams();
   if (alert.query && alert.query.trim()) params.set('q', alert.query.trim());
   const filters = alert.filters || {};
-  for (const group of ['cat', 'maker', 'cond', 'src', 'region']) {
+  for (const group of ['cat', 'maker', 'cond', 'src', 'state']) {
     const g = filters[group];
     if (g && typeof g === 'object') {
       const keys = Object.keys(g).filter((k) => g[k]);
@@ -61,7 +61,7 @@ function summarizeAlert(alert) {
   const parts = [];
   if (alert.query && alert.query.trim()) parts.push(`"${alert.query.trim()}"`);
   const filters = alert.filters || {};
-  const activeGroups = ['cat', 'maker', 'cond', 'src', 'region'].filter((g) => {
+  const activeGroups = ['cat', 'maker', 'cond', 'src', 'state'].filter((g) => {
     const m = filters[g];
     return m && Object.values(m).some(Boolean);
   });

--- a/functions/alerts/predicates.js
+++ b/functions/alerts/predicates.js
@@ -5,31 +5,6 @@
  * out, so it's trivially testable.
  */
 
-// Census Bureau 4-region split (DC bucketed with South). Mirrored client-side
-// in `src/firebase/adapters/externalListingAdapter.js` — small + stable, no
-// shared util because the ESM/CJS divide makes that more trouble than it's
-// worth at our scale.
-const STATE_TO_REGION = {
-  CT: 'Northeast', ME: 'Northeast', MA: 'Northeast', NH: 'Northeast',
-  NJ: 'Northeast', NY: 'Northeast', PA: 'Northeast', RI: 'Northeast',
-  VT: 'Northeast',
-  IL: 'Midwest', IN: 'Midwest', IA: 'Midwest', KS: 'Midwest',
-  MI: 'Midwest', MN: 'Midwest', MO: 'Midwest', NE: 'Midwest',
-  ND: 'Midwest', OH: 'Midwest', SD: 'Midwest', WI: 'Midwest',
-  AL: 'South', AR: 'South', DE: 'South', DC: 'South', FL: 'South',
-  GA: 'South', KY: 'South', LA: 'South', MD: 'South', MS: 'South',
-  NC: 'South', OK: 'South', SC: 'South', TN: 'South', TX: 'South',
-  VA: 'South', WV: 'South',
-  AK: 'West', AZ: 'West', CA: 'West', CO: 'West', HI: 'West',
-  ID: 'West', MT: 'West', NV: 'West', NM: 'West', OR: 'West',
-  UT: 'West', WA: 'West', WY: 'West',
-};
-
-function regionForState(state) {
-  if (!state) return 'Other';
-  return STATE_TO_REGION[state] || 'Other';
-}
-
 function normQuery(q) {
   return (q || '').trim().toLowerCase();
 }
@@ -116,10 +91,12 @@ function matchesAlert(listing, alert) {
   if (!multiMatch(filters.src, listing.source)) return false;
   if (!ageMatches(listing, filters.age)) return false;
   if (!priceMatches(listing, filters.price)) return false;
-  // Region: derive from listing.location_state. eBay listings carry real
-  // state (from postal-code prefix), so no special-case handling.
-  if (filters.region && Object.keys(filters.region).length > 0) {
-    if (!multiMatch(filters.region, regionForState(listing.location_state))) return false;
+  // Ships-from: alert filters by state code directly. A listing with no
+  // state never matches when this filter is active — same behavior as
+  // search results.
+  if (filters.state && Object.keys(filters.state).length > 0) {
+    if (!listing.location_state) return false;
+    if (!multiMatch(filters.state, listing.location_state)) return false;
   }
 
   return true;

--- a/functions/ingest/SCHEMA.md
+++ b/functions/ingest/SCHEMA.md
@@ -37,7 +37,7 @@ Example: `jimbode__stanley-no-5-type-11-jack-plane`
 | `location_state` | string &#124; null | ISO US state code (e.g. `"NY"`, `"MA"`). Null when source provides no per-listing or per-source location data. Used at read time to derive the region filter. |
 | `location_display` | string &#124; null | Human-readable location for the card (e.g. `"Boston, MA"`, `"Lansing, NY"`). Falls back to `location_state` if null. |
 
-Region (Northeast / Midwest / South / West / Other) is **derived at read time** from `location_state` via the Census Bureau 4-region split. Not stored. The `STATE_TO_REGION` map lives in two places (client `externalListingAdapter.js`, server `functions/alerts/predicates.js`) — same dual-bundle pattern as the source registry.
+The Ships-from filter keys directly off `location_state` — 50 chips (state codes), top-N + Show more pattern. We previously bucketed states into 4 regions (NE/MW/S/W); pulled because users don't drive cross-region for hand tools, so regions were too coarse to be actionable. The `location_region` derivation, `STATE_TO_REGION` map, and `regionForState` helper are gone.
 
 Per-source coverage:
 

--- a/src/Pages/aggregator/AlertsPage.jsx
+++ b/src/Pages/aggregator/AlertsPage.jsx
@@ -44,7 +44,7 @@ function alertToParams(alert) {
   const params = new URLSearchParams();
   if (alert.query && alert.query.trim()) params.set('q', alert.query.trim());
   const filters = alert.filters || {};
-  for (const group of ['cat', 'maker', 'cond', 'src', 'region']) {
+  for (const group of ['cat', 'maker', 'cond', 'src', 'state']) {
     const g = filters[group];
     if (g && typeof g === 'object') {
       const keys = Object.keys(g).filter((k) => g[k]);

--- a/src/Pages/aggregator/ResultsState.jsx
+++ b/src/Pages/aggregator/ResultsState.jsx
@@ -39,7 +39,7 @@ const CHIP_GROUP_PREFIX = {
   cond: 'Condition',
   src: 'Source',
   price: 'Price',
-  region: 'Ships from',
+  state: 'Ships from',
 };
 
 /**
@@ -123,11 +123,10 @@ function filterLocally(raw, state) {
     }
     if (filters?.cond && !filters.cond[l.condition]) return false;
     if (filters?.src && l.source && !filters.src[l.source]) return false;
-    // Region filter — straightforward match against location_region. eBay
-    // items carry real state data (derived from postal-code prefix), so no
-    // special-case handling needed.
-    if (filters?.region && Object.keys(filters.region).length > 0) {
-      if (!filters.region[l.location_region]) return false;
+    // Ships-from filter — match against the listing's location_state. A
+    // listing with no state never matches when this filter is active.
+    if (filters?.state && Object.keys(filters.state).length > 0) {
+      if (!l.location_state || !filters.state[l.location_state]) return false;
     }
     if (filters?.pics?.yes && !l.imageUrl) return false;
     const price = filters?.price;

--- a/src/components/aggregator/FilterRail.jsx
+++ b/src/components/aggregator/FilterRail.jsx
@@ -20,7 +20,7 @@ import React, { useState, useMemo } from 'react';
 import { ChevronDown, SlidersHorizontal } from 'lucide-react';
 
 import { SOURCES } from '../../firebase/adapters/sources';
-import { REGIONS } from '../../firebase/adapters/externalListingAdapter';
+import { US_STATES } from '../../firebase/adapters/externalListingAdapter';
 
 const EYEBROW = {
   fontFamily: "'Outfit', sans-serif",
@@ -316,6 +316,27 @@ const FilterRail = ({
     return result;
   }, [facets, filters]);
 
+  // State options: same selected-pinned-then-count-desc pattern as Brand
+  // and Category. Unlike those, we DO pad with the full US_STATES list at
+  // the end so a low-volume state (ND, WY) is still selectable via the
+  // CheckboxList's "Show more" expand even if zero listings match today.
+  const stateOptions = useMemo(() => {
+    const facetMap = facets?.state || {};
+    const selected = filters?.state || {};
+    const result = [];
+    const seen = new Set();
+    for (const k of Object.keys(selected)) {
+      if (!seen.has(k)) { result.push(k); seen.add(k); }
+    }
+    for (const [k] of Object.entries(facetMap).sort((a, b) => b[1] - a[1])) {
+      if (!seen.has(k)) { result.push(k); seen.add(k); }
+    }
+    for (const k of US_STATES) {
+      if (!seen.has(k)) { result.push(k); seen.add(k); }
+    }
+    return result;
+  }, [facets, filters]);
+
   const priceMin = filters?.price?.min ?? '';
   const priceMax = filters?.price?.max ?? '';
 
@@ -323,7 +344,7 @@ const FilterRail = ({
   const hasAnyFilter = useMemo(() => {
     if (!filters) return false;
     if (filters.price && (filters.price.min != null || filters.price.max != null)) return true;
-    for (const group of ['cat', 'maker', 'cond', 'src', 'pics', 'region']) {
+    for (const group of ['cat', 'maker', 'cond', 'src', 'pics', 'state']) {
       if (filters[group] && Object.keys(filters[group]).length > 0) return true;
     }
     return false;
@@ -413,22 +434,18 @@ const FilterRail = ({
         })}
       </CollapsibleGroup>
 
-      {/* Ships from — US-only. Region is derived at read time from each
-         listing's `location_state`. Coverage: dealers tagged at ingest,
-         FBM parsed from "City, ST", eBay derived from itemLocation postal-
-         code prefix (USPS SCF mapping). The "Other" bucket holds listings
-         we don't yet have state for (mostly forum/Reddit posts and a few
-         dealers whose state hasn't been verified). */}
+      {/* Ships from — state-level US filter. Listings without a state
+         (small forum/Reddit residue, plus FBM listings whose location
+         couldn't be parsed) silently fall through and don't appear under
+         any chip — they DO show up in the default unfiltered view. */}
       <CollapsibleGroup label="Ships from" defaultOpen>
-        {REGIONS.map((region) => (
-          <CheckboxRow
-            key={region}
-            label={region}
-            count={facets?.region?.[region]}
-            checked={Boolean(filters?.region?.[region])}
-            onChange={() => toggleFilter('region', region)}
-          />
-        ))}
+        <CheckboxList
+          options={stateOptions}
+          selected={filters?.state}
+          facets={facets?.state}
+          onToggle={(k) => toggleFilter('state', k)}
+          searchPlaceholder="Filter states…"
+        />
       </CollapsibleGroup>
 
       {/* Category — driven from live facets, count desc, top 12 + Show more.

--- a/src/firebase/adapters/aggregatorFacets.js
+++ b/src/firebase/adapters/aggregatorFacets.js
@@ -95,7 +95,7 @@ export async function getSourceCounts(sourceIds) {
  * option → count. Options with zero hits are omitted.
  */
 export function computeFacets(listings) {
-  const counts = { category: {}, maker: {}, source: {}, condition: {}, region: {} };
+  const counts = { category: {}, maker: {}, source: {}, condition: {}, state: {} };
   if (!Array.isArray(listings)) return counts;
 
   for (const l of listings) {
@@ -112,11 +112,12 @@ export function computeFacets(listings) {
     }
     if (l.source) counts.source[l.source] = (counts.source[l.source] || 0) + 1;
     if (l.condition) counts.condition[l.condition] = (counts.condition[l.condition] || 0) + 1;
-    // Region facet. eBay items DO carry state (derived from itemLocation
-    // postal-code prefix at ingest), so they participate in the count
-    // alongside everything else.
-    if (l.location_region) {
-      counts.region[l.location_region] = (counts.region[l.location_region] || 0) + 1;
+    // State facet. Listings without a state are silently omitted — they'll
+    // still show up in default unfiltered results, but no chip claims them
+    // (a "no-state" chip would be a UX trap, since the label can't honestly
+    // describe what selecting it would do).
+    if (l.location_state) {
+      counts.state[l.location_state] = (counts.state[l.location_state] || 0) + 1;
     }
   }
 

--- a/src/firebase/adapters/externalListingAdapter.js
+++ b/src/firebase/adapters/externalListingAdapter.js
@@ -26,31 +26,17 @@ import { SOURCES, sourceDisplayName } from './sources';
 const COLLECTION = 'externalListings';
 const DEFAULT_LIMIT = 60;
 
-// Census Bureau 4-region split (DC bucketed with South). Derived at read
-// time from `location_state` — never stored. Mirrored server-side in
-// `functions/alerts/predicates.js` for alert matching.
-const STATE_TO_REGION = {
-  CT: 'Northeast', ME: 'Northeast', MA: 'Northeast', NH: 'Northeast',
-  NJ: 'Northeast', NY: 'Northeast', PA: 'Northeast', RI: 'Northeast',
-  VT: 'Northeast',
-  IL: 'Midwest', IN: 'Midwest', IA: 'Midwest', KS: 'Midwest',
-  MI: 'Midwest', MN: 'Midwest', MO: 'Midwest', NE: 'Midwest',
-  ND: 'Midwest', OH: 'Midwest', SD: 'Midwest', WI: 'Midwest',
-  AL: 'South', AR: 'South', DE: 'South', DC: 'South', FL: 'South',
-  GA: 'South', KY: 'South', LA: 'South', MD: 'South', MS: 'South',
-  NC: 'South', OK: 'South', SC: 'South', TN: 'South', TX: 'South',
-  VA: 'South', WV: 'South',
-  AK: 'West', AZ: 'West', CA: 'West', CO: 'West', HI: 'West',
-  ID: 'West', MT: 'West', NV: 'West', NM: 'West', OR: 'West',
-  UT: 'West', WA: 'West', WY: 'West',
-};
-
-export const REGIONS = ['Northeast', 'Midwest', 'South', 'West', 'Other'];
-
-export function regionForState(state) {
-  if (!state) return 'Other';
-  return STATE_TO_REGION[state] || 'Other';
-}
+// Full US state list (50 states + DC), used to seed the Ships-from filter
+// so chips for low-volume states still appear (gated by CheckboxList's
+// top-N + Show more pattern).
+export const US_STATES = [
+  'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DC', 'DE', 'FL',
+  'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME',
+  'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH',
+  'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI',
+  'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI',
+  'WY',
+];
 
 /**
  * Reshape one raw Firestore doc into a tool-card-compatible object.
@@ -66,12 +52,11 @@ export function adaptExternalListing(docId, data) {
     typeof data.price_cents === 'number' ? data.price_cents / 100 : null;
   const imageUrl = Array.isArray(data.images) && data.images.length > 0 ? data.images[0] : null;
 
-  // Location: state is stored, region is derived. `listing.location` is
+  // Location: state is what filtering keys on. `listing.location` is
   // populated for the existing MapPin UI on the card — falls back through
   // display → state → null so a row with only a state code still renders.
   const locationState = data.location_state || null;
   const locationDisplay = data.location_display || null;
-  const locationRegion = regionForState(locationState);
   const cardLocation = locationDisplay || locationState || null;
 
   return {
@@ -92,9 +77,8 @@ export function adaptExternalListing(docId, data) {
     source_url: data.source_url,
     sourceName: sourceDisplayName(data.source),
 
-    // location fields — used by the region filter and card metadata
+    // location fields — used by the Ships-from filter and card metadata
     location_state: locationState,
-    location_region: locationRegion,
     location_display: locationDisplay,
 
     // raw canonical fields preserved for downstream consumers (search, alerts).

--- a/src/hooks/useAggregatorState.js
+++ b/src/hooks/useAggregatorState.js
@@ -10,7 +10,7 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
-const MULTI_GROUPS = ['cat', 'maker', 'cond', 'src', 'pics', 'region'];
+const MULTI_GROUPS = ['cat', 'maker', 'cond', 'src', 'pics', 'state'];
 
 // Some filter groups use opaque keys ("yes" for the pics toggle) where the
 // raw key isn't a great chip label. Map those here.


### PR DESCRIPTION
## Summary
Regions (NE/MW/S/W) were the wrong granularity. Real-world shopper question is "where does this ship from" not "which quadrant" — nobody drives from MA to NJ for a hand plane. Replaces region buckets with state-level chips.

## Changes
- URL key `region` → `state` everywhere (alerts URL serializer included).
- `STATE_TO_REGION`, `regionForState`, `location_region` removed from both client adapter and server alert predicates.
- `aggregatorFacets.computeFacets` buckets by state. Listings with no state are silently omitted — no "Other" chip (avoids the label-vs-behavior trap from earlier).
- `FilterRail` now renders Ships-from via `CheckboxList` (top-N + Show more), seeded with the full 50-state list so low-volume states are still reachable.
- `filterLocally` and `predicates.matchesAlert` updated to match by state directly.

## Test plan
- [x] Production build compiles, eslint clean.
- [ ] Local dev: confirm Ships-from group renders 50 states with counts in count-desc order, top 12 + Show more.
- [ ] Click a state chip — results narrow, URL updates to `?state=NY`.
- [ ] Reload — chip stays selected.
- [ ] Save an alert with state filter, confirm AlertsPage URL serializer round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)