### PR TITLE
Aggregator: add 4 PostHog events for search, clickthrough, ToolScan

### DIFF
--- a/src/Pages/ToolScanPage.js
+++ b/src/Pages/ToolScanPage.js
@@ -7,6 +7,7 @@ import ToolScanCard from '../components/ToolScanCard';
 import ToolScanExampleCard from '../components/ToolScanExampleCard';
 import { getAuth } from 'firebase/auth';
 import { getConfig } from '../utils/environment';
+import { track } from '../utils/analytics';
 // Tool model imports preserved for future marketplace features
 
 const API_URL = process.env.REACT_APP_API_URL || process.env.REACT_APP_FIREBASE_API_URL || getConfig(
@@ -129,6 +130,12 @@ const ToolScanPage = () => {
     setScanning(true);
     setScanError(null);
     setScanResults(null);
+    const scanStartedAt = Date.now();
+    track('toolscan_started', {
+      image_count: selectedFiles.length,
+      has_context: Boolean(context.trim()),
+      is_authed: Boolean(user),
+    });
 
     try {
       const images = await Promise.all(
@@ -171,9 +178,27 @@ const ToolScanPage = () => {
 
       setScanResults(data.results);
       setScanId(data.scanId);
+      const tools = (data.results && data.results.tools) || [];
+      const primary = tools[0] || {};
+      track('toolscan_completed', {
+        status: tools.length === 0 ? 'no_tools' : 'success',
+        tool_count: tools.length,
+        primary_brand: primary.maker || null,
+        primary_type: primary.suggested_subcategory || primary.suggested_category || null,
+        primary_confidence: primary.confidence || null,
+        duration_ms: Date.now() - scanStartedAt,
+        is_authed: Boolean(user),
+      });
     } catch (error) {
       console.error('ToolScan error:', error);
       setScanError(error.message || 'Something went wrong. Please try again.');
+      track('toolscan_completed', {
+        status: 'error',
+        tool_count: 0,
+        error_message: error.message || 'unknown',
+        duration_ms: Date.now() - scanStartedAt,
+        is_authed: Boolean(user),
+      });
     } finally {
       setScanning(false);
     }

--- a/src/Pages/aggregator/ResultsState.jsx
+++ b/src/Pages/aggregator/ResultsState.jsx
@@ -22,6 +22,7 @@ import { getAggregatedListings } from '../../firebase/adapters/externalListingAd
 import { computeFacets, getAggregatorStats, getSourceCounts } from '../../firebase/adapters/aggregatorFacets';
 import { SOURCES } from '../../firebase/adapters/sources';
 import { useAuth } from '../../firebase/hooks/useAuth';
+import { track } from '../../utils/analytics';
 
 import StickyTopBar from '../../components/aggregator/StickyTopBar';
 import FilterRail from '../../components/aggregator/FilterRail';
@@ -290,6 +291,34 @@ const ResultsState = ({ state, actions }) => {
   // Client-side refinement (search query, price, multi-select, condition).
   const filtered = useMemo(() => filterLocally(raw, { query, filters }), [raw, query, filters]);
   const visible = useMemo(() => filtered.slice(0, visibleLimit), [filtered, visibleLimit]);
+
+  // search_submitted analytics event — fires once per stabilized query with
+  // the post-filter result count. Debounced 600ms so typing "festool" doesn't
+  // produce 7 events. Skipped when query is empty (no intent signal).
+  const lastTrackedQueryRef = useRef('');
+  useEffect(() => {
+    const trimmed = (query || '').trim();
+    if (!trimmed) {
+      lastTrackedQueryRef.current = '';
+      return undefined;
+    }
+    if (loading) return undefined;
+    if (trimmed === lastTrackedQueryRef.current) return undefined;
+    const t = setTimeout(() => {
+      lastTrackedQueryRef.current = trimmed;
+      const filterCount = activeFilterChips.length;
+      track('search_submitted', {
+        query: trimmed,
+        query_length: trimmed.length,
+        has_active_filters: filterCount > 0,
+        active_filter_count: filterCount,
+        active_sort: sort,
+        result_count: filtered.length,
+        was_zero_results: filtered.length === 0,
+      });
+    }, 600);
+    return () => clearTimeout(t);
+  }, [query, filtered.length, loading, sort, activeFilterChips.length]);
 
   const facets = useMemo(() => computeFacets(filtered), [filtered]);
 
@@ -865,8 +894,18 @@ const ResultsState = ({ state, actions }) => {
                   gap: 20,
                 }}
               >
-                {visible.map((tool) => (
-                  <ResultCard key={tool.id} listing={tool} />
+                {visible.map((tool, index) => (
+                  <ResultCard
+                    key={tool.id}
+                    listing={tool}
+                    searchContext={{
+                      position: index,
+                      totalResults: filtered.length,
+                      query: (query || '').trim() || null,
+                      activeSort: sort,
+                      activeFilterCount: activeFilterChips.length,
+                    }}
+                  />
                 ))}
               </div>
             )}

--- a/src/components/aggregator/ResultCard.jsx
+++ b/src/components/aggregator/ResultCard.jsx
@@ -23,6 +23,7 @@ import {
 
 import { getSource, KIND_COLORS } from '../../firebase/adapters/sources';
 import { relativeTime } from './relativeTime';
+import { track } from '../../utils/analytics';
 
 const KIND_ICON = {
   Dealer: Store,
@@ -74,7 +75,7 @@ function formatPrice(price, currency = '$') {
 
 const PLACEHOLDER_BG = '#e8e6e0'; // var(--bone-dark) — shown when image is missing
 
-const ResultCard = ({ listing, onSaveAlert }) => {
+const ResultCard = ({ listing, onSaveAlert, searchContext }) => {
   const [hover, setHover] = useState(false);
 
   if (!listing) return null;
@@ -95,6 +96,31 @@ const ResultCard = ({ listing, onSaveAlert }) => {
     if (typeof onSaveAlert === 'function') onSaveAlert(listing);
   };
 
+  const handleCardClick = () => {
+    // Don't preventDefault — the outer anchor still navigates in a new tab.
+    // Fire-and-forget; track() swallows errors so this can never block the
+    // navigation.
+    const ctx = searchContext || {};
+    track('result_clicked', {
+      listing_id: listing.id,
+      source: listing.source,
+      source_kind: source?.kind || null,
+      has_image: Boolean(imageUrl),
+      has_price: typeof listing.price === 'number',
+      price_usd: typeof listing.price === 'number' ? listing.price : null,
+      brand: listing.brand || null,
+      type: listing.canonical_type || listing.type || null,
+      position: ctx.position ?? null,
+      total_results: ctx.totalResults ?? null,
+      query: ctx.query || null,
+      active_sort: ctx.activeSort || null,
+      active_filter_count: ctx.activeFilterCount ?? 0,
+      // Placeholder for future price-vs-comp badging — present from day one
+      // so badge CTR can be sliced without a schema change.
+      deal_score: listing.deal_score ?? null,
+    });
+  };
+
   return (
     <a
       href={listing.source_url || '#'}
@@ -102,6 +128,7 @@ const ResultCard = ({ listing, onSaveAlert }) => {
       rel="noopener noreferrer"
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      onClick={handleCardClick}
       className="block overflow-hidden rounded-card no-underline text-inherit"
       style={{
         background: '#f8f6f2',

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,29 @@
+/**
+ * Thin PostHog wrapper for aggregator instrumentation.
+ *
+ * Usage: `import { track } from '../utils/analytics';`
+ *
+ * Why this layer instead of calling posthog.capture directly:
+ *   - Single place to no-op if PostHog isn't initialized (env without
+ *     REACT_APP_POSTHOG_KEY — local dev, preview deploys without the key).
+ *   - Single place to swallow capture errors so analytics can never break
+ *     the user-facing app.
+ *   - Future hook for adding common context (release version, build mode)
+ *     without touching every call site.
+ *
+ * No batching or queueing here — posthog-js already handles that.
+ */
+
+import posthog from 'posthog-js';
+
+export function track(eventName, properties = {}) {
+  if (!posthog.__loaded) return;
+  try {
+    posthog.capture(eventName, properties);
+  } catch (err) {
+    // Never let analytics break the app
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`[analytics] capture failed for ${eventName}:`, err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the post-pivot instrumentation gap. Before this, only PostHog's default `$autocapture` / `$pageview` noise was firing — none of the aggregator's intent or conversion signals were captured. Verified via PostHog query: zero events for `result_clicked`, `search_submitted`, ToolScan funnel.

Four new events:

- **`search_submitted`** — debounced 600ms, fires on stabilized query with post-filter `result_count`. Lets us measure zero-result queries and what people actually search for.
- **`result_clicked`** — the conversion event. Fires alongside source navigation on `ResultCard` click; carries `source` / `brand` / `type` / `position` / `active_sort` context plus a `deal_score` placeholder for future price-vs-comp badging (so the badge can be sliced on day one without a schema change).
- **`toolscan_started`** — fires on image submit.
- **`toolscan_completed`** — `status` is `success` / `error` / `no_tools`; carries `duration_ms`, `primary_brand`, `primary_type`. Enables a ToolScan funnel.

## Architecture

- New `src/utils/analytics.js` wrapper that no-ops when `REACT_APP_POSTHOG_KEY` isn't set (local dev, preview deploys) and swallows capture errors so analytics can never break the app.
- PostHog client itself is already initialized in `src/index.js`; `useAuth.js` already calls `posthog.identify`. No init changes.
- Existing `alert_created` / `alert_deleted` captures in `savedSearchModel.js` are unchanged.

## Out of scope (deliberate cuts)

- `filter_changed` and `sort_changed` — useful but lower-leverage, can land in a follow-up.
- Cleanup of orphaned legacy marketplace events (`offer_*`, `tool_listed`, etc.) — gated behind `MarketplaceRoute`, won't fire for normal users; flag for later cleanup.

## Test plan

- [ ] Build passes (`CI=true npm run build`) ✅ verified locally (+606 B gzipped)
- [ ] On prod after deploy: type a query in the aggregator, confirm a single `search_submitted` fires after typing stops (not per keystroke).
- [ ] Click a result card: confirm `result_clicked` fires with full property bag (source, brand, position, etc.).
- [ ] Run ToolScan with an image: confirm `toolscan_started` fires on submit and `toolscan_completed` fires once with `status: success` and a non-null `primary_brand`.
- [ ] Trigger a ToolScan error (oversized file rejected upstream — or pull network mid-scan): confirm `toolscan_completed` fires with `status: error` and `error_message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)